### PR TITLE
names: renaming 'extension' things to be 'stack' things, updating stack to assume default policies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,4 +24,4 @@ bin
 *~
 
 # Stackages
-extension-package/
+stack-package/

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,9 +18,9 @@ COPY controllers/ controllers/
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -o manager main.go
 
 # Use alpine as a minimal base image to package the manager binary
-# Alpine is used instead of distroless because the extension manager expects things like `cp` to exist
+# Alpine is used instead of distroless because the stack manager expects things like `cp` to exist
 FROM alpine:3.7
 WORKDIR /
-COPY extension-package /
+COPY stack-package /
 COPY --from=builder /workspace/manager .
 ENTRYPOINT ["/manager"]

--- a/PROJECT
+++ b/PROJECT
@@ -1,6 +1,6 @@
 version: "2"
-domain: samples.extensions.crossplane.io
-repo: github.com/crossplaneio/sample-wordpress-extension
+domain: samples.stacks.crossplane.io
+repo: github.com/crossplaneio/sample-stack-wordpress
 resources:
 - group: wordpress
   version: v1alpha1

--- a/api/v1alpha1/groupversion_info.go
+++ b/api/v1alpha1/groupversion_info.go
@@ -15,7 +15,7 @@ limitations under the License.
 
 // Package v1alpha1 contains API Schema definitions for the wordpress v1alpha1 API group
 // +kubebuilder:object:generate=true
-// +groupName=wordpress.samples.extensions.crossplane.io
+// +groupName=wordpress.samples.stacks.crossplane.io
 package v1alpha1
 
 import (
@@ -25,7 +25,7 @@ import (
 
 var (
 	// GroupVersion is group version used to register these objects
-	GroupVersion = schema.GroupVersion{Group: "wordpress.samples.extensions.crossplane.io", Version: "v1alpha1"}
+	GroupVersion = schema.GroupVersion{Group: "wordpress.samples.stacks.crossplane.io", Version: "v1alpha1"}
 
 	// SchemeBuilder is used to add go types to the GroupVersionKind scheme
 	SchemeBuilder = &scheme.Builder{GroupVersion: GroupVersion}

--- a/api/v1alpha1/wordpressinstance_types.go
+++ b/api/v1alpha1/wordpressinstance_types.go
@@ -56,7 +56,7 @@ type WordpressInstanceList struct {
 	Items           []WordpressInstance `json:"items"`
 }
 
-// StackRequest type metadata.
+// WordpressInstance type metadata.
 var (
 	WordpressInstanceKind             = reflect.TypeOf(WordpressInstance{}).Name()
 	WordpressInstanceKindAPIVersion   = WordpressInstanceKind + "." + GroupVersion.String()

--- a/api/v1alpha1/wordpressinstance_types.go
+++ b/api/v1alpha1/wordpressinstance_types.go
@@ -56,7 +56,7 @@ type WordpressInstanceList struct {
 	Items           []WordpressInstance `json:"items"`
 }
 
-// ExtensionRequest type metadata.
+// StackRequest type metadata.
 var (
 	WordpressInstanceKind             = reflect.TypeOf(WordpressInstance{}).Name()
 	WordpressInstanceKindAPIVersion   = WordpressInstanceKind + "." + GroupVersion.String()

--- a/config/crd/bases/wordpress.samples.stacks.crossplane.io_wordpressinstances.yaml
+++ b/config/crd/bases/wordpress.samples.stacks.crossplane.io_wordpressinstances.yaml
@@ -4,9 +4,9 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   creationTimestamp: null
-  name: wordpressinstances.wordpress.samples.extensions.crossplane.io
+  name: wordpressinstances.wordpress.samples.stacks.crossplane.io
 spec:
-  group: wordpress.samples.extensions.crossplane.io
+  group: wordpress.samples.stacks.crossplane.io
   names:
     kind: WordpressInstance
     plural: wordpressinstances

--- a/config/crd/kustomization.yaml
+++ b/config/crd/kustomization.yaml
@@ -2,7 +2,7 @@
 # since it depends on service name and namespace that are out of this kustomize package.
 # It should be run by config/default
 resources:
-- bases/wordpress.samples.extensions.crossplane.io_wordpressinstances.yaml
+- bases/wordpress.samples.stacks.crossplane.io_wordpressinstances.yaml
 # +kubebuilder:scaffold:crdkustomizeresource
 
 patches:

--- a/config/crd/patches/cainjection_in_wordpressinstances.yaml
+++ b/config/crd/patches/cainjection_in_wordpressinstances.yaml
@@ -5,4 +5,4 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     certmanager.k8s.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
-  name: wordpressinstances.wordpress.samples.extensions.crossplane.io
+  name: wordpressinstances.wordpress.samples.stacks.crossplane.io

--- a/config/crd/patches/webhook_in_wordpressinstances.yaml
+++ b/config/crd/patches/webhook_in_wordpressinstances.yaml
@@ -3,7 +3,7 @@
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  name: wordpressinstances.wordpress.samples.extensions.crossplane.io
+  name: wordpressinstances.wordpress.samples.stacks.crossplane.io
 spec:
   conversion:
     strategy: Webhook

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -1,12 +1,12 @@
 # Adds namespace to all resources.
-namespace: sample-wordpress-extension-system
+namespace: sample-wordpress-stack-system
 
 # Value of this field is prepended to the
 # names of all resources, e.g. a deployment named
 # "wordpress" becomes "alices-wordpress".
 # Note that it should also match with the prefix (text before '-') of the namespace
 # field above.
-namePrefix: sample-wordpress-extension-
+namePrefix: sample-wordpress-stack-
 
 # Labels to add to all resources and selectors.
 #commonLabels:

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -7,7 +7,7 @@ metadata:
   name: manager-role
 rules:
 - apiGroups:
-  - wordpress.samples.extensions.crossplane.io
+  - wordpress.samples.stacks.crossplane.io
   resources:
   - wordpressinstances
   verbs:
@@ -19,7 +19,7 @@ rules:
   - update
   - watch
 - apiGroups:
-  - wordpress.samples.extensions.crossplane.io
+  - wordpress.samples.stacks.crossplane.io
   resources:
   - wordpressinstances/status
   verbs:

--- a/config/samples/install.extension.yaml
+++ b/config/samples/install.extension.yaml
@@ -1,8 +1,0 @@
----
-apiVersion: extensions.crossplane.io/v1alpha1
-kind: ExtensionRequest
-metadata:
-  name: sample-wordpress-extension-from-package
-spec:
-  source: localhost:5000
-  package: crossplane-examples/wordpress-stack

--- a/config/samples/install.stack.yaml
+++ b/config/samples/install.stack.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: stacks.crossplane.io/v1alpha1
+kind: StackRequest
+metadata:
+  name: sample-wordpress-stack-from-package
+spec:
+  source: localhost:5000
+  package: crossplane-examples/wordpress-stack

--- a/config/samples/overrides/install.yaml
+++ b/config/samples/overrides/install.yaml
@@ -2,5 +2,5 @@ spec:
   template:
     spec:
       containers:
-      - name: sample-wordpress-extension-controller
+      - name: sample-wordpress-stack-controller
         image: localhost:5000/crossplane-examples/wordpress-stack

--- a/config/samples/wordpress_v1alpha1_wordpressinstance.yaml
+++ b/config/samples/wordpress_v1alpha1_wordpressinstance.yaml
@@ -1,4 +1,4 @@
-apiVersion: wordpress.samples.extensions.crossplane.io/v1alpha1
+apiVersion: wordpress.samples.stacks.crossplane.io/v1alpha1
 kind: WordpressInstance
 metadata:
   name: wordpressinstance-sample

--- a/config/stack/app.yaml
+++ b/config/stack/app.yaml
@@ -1,9 +1,9 @@
 # Human readable title of application.
-title: Sample Wordpress Extension
+title: Sample Wordpress Stack
 
 # Markdown description of this entry
 description: |
- Markdown describing this sample Crossplane extension project.
+ Markdown describing this sample Crossplane stack project.
 
 # Version of project (optional)
 # If omitted the version will be filled with the docker tag

--- a/config/stack/install.yaml
+++ b/config/stack/install.yaml
@@ -1,22 +1,22 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: crossplane-sample-wordpress-extension
+  name: crossplane-sample-wordpress-stack
   labels:
-    core.crossplane.io/name: "crossplane-sample-wordpress-extension"
+    core.crossplane.io/name: "crossplane-sample-wordpress-stack"
 spec:
   selector:
     matchLabels:
-      core.crossplane.io/name: "crossplane-sample-wordpress-extension"
+      core.crossplane.io/name: "crossplane-sample-wordpress-stack"
   replicas: 1
   template:
     metadata:
-      name: sample-wordpress-extension-controller
+      name: sample-wordpress-stack-controller
       labels:
-        core.crossplane.io/name: "crossplane-sample-wordpress-extension"
+        core.crossplane.io/name: "crossplane-sample-wordpress-stack"
     spec:
       containers:
-      - name: sample-wordpress-extension-controller
+      - name: sample-wordpress-stack-controller
         image: crossplane-examples/wordpress-stack
         env:
         - name: POD_NAME

--- a/config/stack/rbac.yaml
+++ b/config/stack/rbac.yaml
@@ -1,6 +1,6 @@
 rules:
 - apiGroups:
-  - wordpress.samples.extensions.crossplane.io
+  - wordpress.samples.stacks.crossplane.io
   resources:
   - wordpressinstances
   verbs:
@@ -12,7 +12,7 @@ rules:
   - update
   - watch
 - apiGroups:
-  - wordpress.samples.extensions.crossplane.io
+  - wordpress.samples.stacks.crossplane.io
   resources:
   - wordpressinstances/status
   verbs:

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -22,7 +22,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
-	wordpressv1alpha1 "github.com/crossplaneio/sample-wordpress-extension/api/v1alpha1"
+	wordpressv1alpha1 "github.com/crossplaneio/sample-stack-wordpress/api/v1alpha1"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"

--- a/controllers/wordpressinstance_controller.go
+++ b/controllers/wordpressinstance_controller.go
@@ -31,7 +31,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	wordpressv1alpha1 "github.com/crossplaneio/sample-wordpress-extension/api/v1alpha1"
+	wordpressv1alpha1 "github.com/crossplaneio/sample-stack-wordpress/api/v1alpha1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -42,8 +42,8 @@ type WordpressInstanceReconciler struct {
 	Log logr.Logger
 }
 
-// +kubebuilder:rbac:groups=wordpress.samples.extensions.crossplane.io,resources=wordpressinstances,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=wordpress.samples.extensions.crossplane.io,resources=wordpressinstances/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=wordpress.samples.stacks.crossplane.io,resources=wordpressinstances,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=wordpress.samples.stacks.crossplane.io,resources=wordpressinstances/status,verbs=get;update;patch
 
 func (r *WordpressInstanceReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	ctx := context.Background()
@@ -222,7 +222,7 @@ spec:
 
 	// TODO
 	// Return a reconcile error when there's an issue
-	// Set instance owner as the Stack / Extension?
+	// Set instance owner as the Stack?
 	// Add labels to resources created by individual wordpress instance, and put that
 	//     same label on the instance. For later querying
 	// Maybe put the IP of the load balancer in the wordpress instance CRD

--- a/controllers/wordpressinstance_controller.go
+++ b/controllers/wordpressinstance_controller.go
@@ -77,9 +77,6 @@ metadata:
 spec:
   writeConnectionSecretToRef:
     name: wordpress-demo-cluster-{{ .UID }}
-  classRef:
-    name: standard-cluster
-    namespace: crossplane-system
 ---
 apiVersion: database.crossplane.io/v1alpha1
 kind: MySQLInstance
@@ -89,9 +86,6 @@ metadata:
   labels:
     stack: sample-stack-wordpress
 spec:
-  classRef:
-    name: standard-mysql
-    namespace: crossplane-system
   engineVersion: "5.7"
   # A secret is exported by providing the secret name
   # to export it under. This is the name of the secret

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/crossplaneio/sample-wordpress-extension
+module github.com/crossplaneio/sample-stack-wordpress
 
 go 1.12
 

--- a/main.go
+++ b/main.go
@@ -19,8 +19,8 @@ import (
 	"flag"
 	"os"
 
-	wordpressv1alpha1 "github.com/crossplaneio/sample-wordpress-extension/api/v1alpha1"
-	"github.com/crossplaneio/sample-wordpress-extension/controllers"
+	wordpressv1alpha1 "github.com/crossplaneio/sample-stack-wordpress/api/v1alpha1"
+	"github.com/crossplaneio/sample-stack-wordpress/controllers"
 	"k8s.io/apimachinery/pkg/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"


### PR DESCRIPTION
Related to crossplaneio/crossplane#732

## Overview

We renamed crossplane extensions to be crossplane stacks, including
stack structure folder names and Kinds, so this renames them in this
stack too.

## Testing done

Ad-hoc local testing by building and installing the extension, against crossplaneio/crossplane@d9783258f6538db78c9163e6860ee2100db9ca16

## Notes for reviewers

This is more intended as an FYI than a thing that will block on a review before being merged, but feel free to leave comments! I'll revisit any comments in a future changeset.