### PR TITLE
permissions: add permissions for mysql and kubernetes resources

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -7,6 +7,30 @@ metadata:
   name: manager-role
 rules:
 - apiGroups:
+  - compute.crossplane.io
+  resources:
+  - kubernetesclusters
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - database.crossplane.io
+  resources:
+  - mysqlinstances
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
   - wordpress.samples.stacks.crossplane.io
   resources:
   - wordpressinstances
@@ -26,3 +50,15 @@ rules:
   - get
   - patch
   - update
+- apiGroups:
+  - workload.crossplane.io
+  resources:
+  - kubernetesapplication
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch

--- a/controllers/wordpressinstance_controller.go
+++ b/controllers/wordpressinstance_controller.go
@@ -44,6 +44,9 @@ type WordpressInstanceReconciler struct {
 
 // +kubebuilder:rbac:groups=wordpress.samples.stacks.crossplane.io,resources=wordpressinstances,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=wordpress.samples.stacks.crossplane.io,resources=wordpressinstances/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=compute.crossplane.io,resources=kubernetesclusters,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=database.crossplane.io,resources=mysqlinstances,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=workload.crossplane.io,resources=kubernetesapplication,verbs=get;list;watch;create;update;patch;delete
 
 func (r *WordpressInstanceReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	ctx := context.Background()


### PR DESCRIPTION
## Overview

More permissions are needed for the wordpress controller to create
everything it's trying to create. The reason it wasn't noticed locally
before was because docker for Mac's Kubernetes implementation had a
cluster role which gave all service accounts cluster admin.

## Testing done

Ran `make integration-test` locally and checked to make sure the needed resources were created.

## Notes for reviewers

* This will need to be revisited when the rbac logic is updated in the Crossplane stack manager, as tracked by crossplaneio/crossplane#754
* This is more of an FYI than a changeset which will block merging on a review. But, feel free to leave comments, and if the code is already merged, I will revisit them in the future!