### PR TITLE
add missing permissions to controller rbac

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -7,6 +7,18 @@ metadata:
   name: manager-role
 rules:
 - apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
   - compute.crossplane.io
   resources:
   - kubernetesclusters
@@ -22,6 +34,18 @@ rules:
   - database.crossplane.io
   resources:
   - mysqlinstances
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - workload.crossplane.io
+  resources:
+  - kubernetesapplications
   verbs:
   - create
   - delete


### PR DESCRIPTION
Namespace creation and KubernetesApplication management rules are needed for objects in Crossplane cluster to be deployed correctly.

@suskin let me know if that wasn't the right file to edit.