### PR TITLE
Updates the Stack for the Crossplane v0.3 milestone (metadata and isolation)

### DIFF
--- a/config/stack/manifests/app.yaml
+++ b/config/stack/manifests/app.yaml
@@ -31,11 +31,16 @@ keywords:
 - "wordpress"
 
 # Links to more information about the application (about page, source code, etc.)
-links:
-- description: Website
-  url: "https://upbound.io"
-- description: Source Code
-  url: "https://github.com/crossplaneio/sample-stack-wordpress"
+website: "https://upbound.io"
+source: "https://github.com/crossplaneio/sample-stack-wordpress"
+
+# RBAC Roles will be generated permitting this stack to use all verbs on all
+# resources in the groups listed below.
+permissionScope: Namespaced
+dependsOn:
+- crd: "kubernetesclusters.compute.crossplane.io/v1alpha1"
+- crd: "mysqlinstances.database.crossplane.io/v1alpha1"
+- crd: "kubernetesapplications.workload.crossplane.io/v1alpha1"
 
 # License SPDX name: https://spdx.org/licenses/
 license: Apache-2.0

--- a/config/stack/samples/install.stack.yaml
+++ b/config/stack/samples/install.stack.yaml
@@ -1,6 +1,6 @@
 ---
 apiVersion: stacks.crossplane.io/v1alpha1
-kind: StackRequest
+kind: StackInstall
 metadata:
   name: "crossplane-sample-stack-wordpress"
 spec:

--- a/config/stack/samples/local.install.stack.yaml
+++ b/config/stack/samples/local.install.stack.yaml
@@ -1,6 +1,6 @@
 ---
 apiVersion: stacks.crossplane.io/v1alpha1
-kind: StackRequest
+kind: StackInstall
 metadata:
   name: "crossplane-sample-stack-wordpress"
 spec:


### PR DESCRIPTION
Updates the Stack for the Crossplane v0.3 milestone (metadata and isolation), requiring crossplaneio/crossplane#729.

* Set the `permissionScope` in `app.yaml` to "Namespaced"
* Set the `dependsOn` crd resources in `app.yaml`
* Update the example stack install yaml files for the new kind:
  `StackInstall`

Partly addresses https://github.com/crossplaneio/crossplane/issues/754