### PR TITLE
Watch for resources only in the namespace that this controller runs in

### DIFF
--- a/stack.Makefile
+++ b/stack.Makefile
@@ -37,7 +37,7 @@ publish: docker-push
 # Initialize the stack bundle folder
 $(STACK_PACKAGE_REGISTRY):
 	mkdir -p $(STACK_PACKAGE_REGISTRY)/resources
-	touch $(STACK_PACKAGE_REGISTRY)/app.yaml $(STACK_PACKAGE_REGISTRY)/install.yaml $(STACK_PACKAGE_REGISTRY)/rbac.yaml
+	touch $(STACK_PACKAGE_REGISTRY)/app.yaml $(STACK_PACKAGE_REGISTRY)/install.yaml
 
 bundle: $(STACK_PACKAGE_REGISTRY)
 	# Copy CRDs over
@@ -53,9 +53,6 @@ bundle: $(STACK_PACKAGE_REGISTRY)
 		$(STACK_PACKAGE_REGISTRY)/resources/$$( basename $$(echo $$filename | sed s/.yaml$$/.crd.yaml/)) \
 		; done
 
-	# If RBAC_GLOB is set *and* there is an rbac.yaml in the registry
-	# source folder, the registry source will win.
-	cat $(RBAC_GLOB) > $(STACK_PACKAGE_REGISTRY)/rbac.yaml
 	cp -r $(STACK_PACKAGE_REGISTRY_SOURCE)/* $(STACK_PACKAGE_REGISTRY)
 .PHONY: bundle
 

--- a/stack.env
+++ b/stack.env
@@ -3,10 +3,6 @@ STACK_IMG ?= crossplane/sample-stack-wordpress:latest
 IMG=$(STACK_IMG)
 
 CRD_DIR=config/crd/bases
-# Files matching this glob will be placed into the stack's
-# rbac.yaml. It could be multiple filenames or multiple
-# glob patterns.
-RBAC_GLOB=config/rbac/role.yaml
 STACK_PACKAGE_REGISTRY_SOURCE=config/stack/manifests
 LOCAL_OVERRIDES_DIR=config/stack/overrides
 CONFIG_SAMPLES_DIR=config/stack/samples


### PR DESCRIPTION
This PR makes it so the wordpress controller will only watch for resources in the namespace that the controller is running in.  We are already injecting the pod's namespace into the deployment and pod via the downward API, so we just need to pass this along to the controller manager.

This PR also cleans up RBAC related metadata and build logic that is no longer needed.

I have tested this end to end locally by building the stack package and copying it to minikube, then using the Stack Manager to install it.  Then I created a WordpressInstance resource and verified that the controller was able to create all the expected claims (mysql, kubernetescluster, etc.)