### PR TITLE
stacks: add overview fields to app.yaml

### DIFF
--- a/config/stack/manifests/app.yaml
+++ b/config/stack/manifests/app.yaml
@@ -1,9 +1,34 @@
 # Human readable title of application.
 title: Sample Wordpress Stack
 
+overviewShort: Cloud portable Wordpress deployments behind managed Kubernetes and SQL services are demonstrated in this Crossplane Stack.
+overview: |-
+ This Wordpress stack uses a simple controller that uses Crossplane to orchestrate managed SQL services and managed Kubernetes clusters which are then used to run a Wordpress deployment.
+
+ A simple Custom Resource Definition (CRD) is provided allowing for instances of this Crossplane managed Wordpress Stack to be provisioned with a few lines of yaml.
+
+ The Sample Wordpress Stack is intended for demonstration purposes and should not be used to deploy production instances of Wordpress.
+
 # Markdown description of this entry
-description: |
- Markdown describing this sample Crossplane stack project.
+readme: |-
+ ### Create wordpresses
+
+ Before wordpresses will provision, the Crossplane control cluster must
+ be configured to connect to a provider (e.g. GCP, Azure, AWS).
+
+ Once a provider is configured, starting the process of creating a
+ Wordpress Stack instance is easy.
+
+ ```shell
+ cat <<EOF | kubectl apply -f -
+ apiVersion: wordpress.samples.stacks.crossplane.io/v1alpha1
+ kind: WordpressInstance
+ metadata:
+   name: wordpressinstance-sample
+ EOF
+ ```
+
+ The stack (and Crossplane) will take care of the rest.
 
 # Version of project (optional)
 # If omitted the version will be filled with the docker tag


### PR DESCRIPTION
The following changes are being made to the `app.yaml` stack file to
address the needs of crossplaneio/crossplane#745.

* `description` renamed to `readme`
  Because the old `description` field and the new `readme` field both
  support markdown, the `description` text is being repurposed as
  `readme`.
* `overview` is added.
  Overview is a plain text description of the stack. The broad services
  provided by the stack should be described.  This is a high level view
  of the stack and does not necessarily need to describe the
  implementation details of the stack.
* `overviewShort` is added
  * the overview short not duplicate the title
  * the overview short is a one-line alternative for overview

Part of https://github.com/crossplaneio/crossplane/issues/745

[skip ci]

