### PR TITLE
docs: add instructions for publishing

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,3 +65,20 @@ To run locally out-of-cluster:
 1. Delete the deployment that the stack manager created
 2. `make run`; I like to use `make manager run` to ensure that it
    rebuilds
+
+
+### How to publish the latest version of the stack
+
+Build the controller, bundle the stack, and publish the stack:
+
+```
+make
+kubectl crossplane stack build
+kubectl crossplane stack publish
+```
+
+You may also need to log into docker:
+
+```
+docker login
+```


### PR DESCRIPTION
## Overview

Publishing is still done by hand (we should automate it at some point),
so it's helpful to have the instructions in the README.

## Testing done

I ran these commands earlier today to publish [the most recent version of the stack](https://hub.docker.com/layers/crossplane/sample-stack-wordpress/latest/images/sha256-36446dfa822b73d7b427f4b22d812621e5325b5bfaf035c5d13a15c8cd202af0).