### PR TITLE
rbac: add kubernetesapplicationresource to dependent CRDs

### DIFF
--- a/config/stack/manifests/app.yaml
+++ b/config/stack/manifests/app.yaml
@@ -66,6 +66,7 @@ dependsOn:
 - crd: "kubernetesclusters.compute.crossplane.io/v1alpha1"
 - crd: "mysqlinstances.database.crossplane.io/v1alpha1"
 - crd: "kubernetesapplications.workload.crossplane.io/v1alpha1"
+- crd: "kubernetesapplicationresources.workload.crossplane.io/v1alpha1"
 
 # License SPDX name: https://spdx.org/licenses/
 license: Apache-2.0


### PR DESCRIPTION
With the new RBAC mechanisms in Crossplane 0.6.0, all stacks have to list the CRDs they might want to work with. This PR adds `KubernetesApplicationResource` to that list since it queries `service` kind `KubernetesApplicationResource` to get the endpoint.