### PR TITLE
Add publishing pipeline builds (release-0.0)

### DIFF
--- a/Jenkinsfile.branch
+++ b/Jenkinsfile.branch
@@ -1,0 +1,50 @@
+pipeline {
+    agent { label 'upbound-gce' }
+
+    parameters {
+        string(name: 'branch', defaultValue: '', description: 'Required. The release branch to create. For example: "release-0.0". This should typically be "release-MAJOR.MINOR".')
+        string(name: 'commit', defaultValue: '', description: 'Optional. Commit hash to use as the head of the branch. For example: 56b65dba917e50132b0a540ae6ff4c5bbfda2db6. If empty, the latest commit hash on the current branch will be used.')
+    }
+
+    options {
+        disableConcurrentBuilds()
+        timestamps()
+    }
+
+    environment {
+        GITHUB_UPBOUND_BOT = credentials('github-upbound-jenkins')
+    }
+
+    stages {
+
+        stage('Prepare') {
+            steps {
+                 // github credentials are not setup to push over https in jenkins. add the github token to the url
+                sh "git config remote.origin.url https://${GITHUB_UPBOUND_BOT_USR}:${GITHUB_UPBOUND_BOT_PSW}@\$(git config --get remote.origin.url | sed -e 's/https:\\/\\///')"
+                sh 'git config user.name "upbound-bot"'
+                sh 'git config user.email "info@crossplane.io"'
+                sh 'echo "machine github.com login upbound-bot password $GITHUB_UPBOUND_BOT" > ~/.netrc'
+            }
+        }
+
+        stage('Tag Release') {
+            steps {
+                sh "test -n '${params.branch}' || ( echo 'Branch is required - please enter a branch!' && exit 1 )"
+                // If the commit is not passed, it'll be empty, which means git will use the head
+                // of the current branch. Most of the time, the default behavior will be used (from master).
+                //
+                // For the push, we're assuming the remote is named "origin", but this is the convention,
+                // so it's a safe assumption for this situation.
+                sh """git branch ${params.branch} ${params.commit}
+                      git push origin ${params.branch}
+                """
+            }
+        }
+    }
+
+    post {
+        always {
+            deleteDir()
+        }
+    }
+}

--- a/Jenkinsfile.publish
+++ b/Jenkinsfile.publish
@@ -1,0 +1,49 @@
+pipeline {
+    agent { label 'upbound-gce' }
+
+    parameters {
+        string(name: 'version', defaultValue: '', description: 'The version you are publishing. For example: v0.4.0. If left unspecified, the build will generate one for you.')
+    }
+
+    options {
+        disableConcurrentBuilds()
+        timestamps()
+    }
+
+    environment {
+        DOCKER = credentials('dockerhub-upboundci')
+        CROSSPLANE_CLI_RELEASE = 'v0.2.0'
+    }
+
+    stages {
+        stage('Prepare') {
+            steps {
+                sh 'mkdir bin'
+                sh "curl -sL https://raw.githubusercontent.com/crossplaneio/crossplane-cli/${CROSSPLANE_CLI_RELEASE}/bootstrap.sh | env PREFIX=${WORKSPACE} RELEASE=${CROSSPLANE_CLI_RELEASE} bash"
+            }
+        }
+        stage('Promote Release') {
+
+            steps {
+                // The build step turns this into a "dirty" environment from the perspective of `git describe`,
+                // so we set the version once at the beginning and use it for both the build and publish steps.
+
+                sh """STACK_VERSION=${params.version}
+                      STACK_VERSION=\${STACK_VERSION:-\$( git describe --tags --dirty --always )}
+                      STACK_VERSION=\${STACK_VERSION} ./bin/kubectl-crossplane-stack-build
+                      STACK_VERSION=\${STACK_VERSION} ./bin/kubectl-crossplane-stack-publish
+                """
+            }
+        }
+    }
+
+    post {
+        always {
+            script {
+                sh 'make -j\$(nproc) clean'
+                sh './bin/kubectl-crossplane-stack-build clean'
+                deleteDir()
+            }
+        }
+    }
+}

--- a/Jenkinsfile.tag
+++ b/Jenkinsfile.tag
@@ -1,0 +1,53 @@
+pipeline {
+    agent { label 'upbound-gce' }
+
+    parameters {
+        string(name: 'version', defaultValue: '', description: 'The version you are tagging. For example: v0.4.0. If left unspecified, the build will generate one for you.')
+        string(name: 'commit', defaultValue: '', description: 'Optional commit hash to tag. For example: 56b65dba917e50132b0a540ae6ff4c5bbfda2db6. If empty, the latest commit hash will be used.')
+    }
+
+    options {
+        disableConcurrentBuilds()
+        timestamps()
+    }
+
+    environment {
+        GITHUB_UPBOUND_BOT = credentials('github-upbound-jenkins')
+    }
+
+    stages {
+
+        stage('Prepare') {
+            steps {
+                 // github credentials are not setup to push over https in jenkins. add the github token to the url
+                sh "git config remote.origin.url https://${GITHUB_UPBOUND_BOT_USR}:${GITHUB_UPBOUND_BOT_PSW}@\$(git config --get remote.origin.url | sed -e 's/https:\\/\\///')"
+                sh 'git config user.name "upbound-bot"'
+                sh 'git config user.email "info@crossplane.io"'
+                sh 'echo "machine github.com login upbound-bot password $GITHUB_UPBOUND_BOT" > ~/.netrc'
+            }
+        }
+
+        stage('Tag Release') {
+            steps {
+                // The first few lines set the version - it uses the passed version, or
+                // generates one.
+                // If the commit is not passed, it'll be empty, which means git will tag the head
+                // of the current branch. Most of the time, the default behavior will be used.
+                //
+                // For the push, we're assuming the remote is named "origin", but this is the convention,
+                // so it's a safe assumption for this situation.
+                sh """VERSION='${params.version}'
+                      VERSION=\${VERSION:-\$( git describe --tags --dirty --always )}
+                      git tag -f -m "release \${VERSION}" \${VERSION} ${params.commit}
+                      git push origin \${VERSION}
+                """
+            }
+        }
+    }
+
+    post {
+        always {
+            deleteDir()
+        }
+    }
+}

--- a/stack.env
+++ b/stack.env
@@ -1,5 +1,8 @@
+# This is intended to be included from inside a Makefile
+
+STACK_VERSION ?= latest
 # Image URL to use all building/pushing image targets
-STACK_IMG ?= crossplane/sample-stack-wordpress:latest
+STACK_IMG ?= crossplane/sample-stack-wordpress:$(STACK_VERSION)
 IMG=$(STACK_IMG)
 
 CRD_DIR=config/crd/bases


### PR DESCRIPTION
## Overview

This adds Jenkinsfiles for our publishing pipeline:

* `Jenkinsfile.tag`, for tagging commits
* `Jenkinsfile.publish`, for publishing commits to dockerhub
* `Jenkinsfile.branch`, for creating release branches

The Jenkinsfiles are identical to the ones in #33 .

It's intended to be used in the [upbound Jenkins](https://jenkinsci.upbound.io/job/crossplaneio/job/sample-stack-wordpress), and is similar to existing publishing pipelines.

There are two types of builds:

* Continuous, from master, whenever a commit is pushed
* On-demand, from a release branch

This adds the functionality for both, but we will need additional setup to trigger the builds when a commit is pushed:

* [ ] Configure a webhook to trigger the build for the master branch

Also, out of scope are labeled channel updates (such as `alpha`).

Note that some additional work will probably be needed in order to fit this into the template stacks version of the stack.

## Testing done

I've done a bunch of testing in the [upbound Jenkins](https://jenkinsci.upbound.io/job/crossplaneio/job/sample-stack-wordpress), with a private dockerhub repository. I've done tagging and publishing and seen them succeed.

## After this is merged

After this is merged, we'll need to clean up the existing job and try out the process:

* [ ] Point the job back at `crossplaneio` instead of `suskin`
* [ ] Run a release of `0.0.1` using the new jobs
* [x] Document the new release process