### PR TITLE
Add publishing pipeline builds (master)

### DIFF
--- a/Jenkinsfile.branch
+++ b/Jenkinsfile.branch
@@ -1,0 +1,50 @@
+pipeline {
+    agent { label 'upbound-gce' }
+
+    parameters {
+        string(name: 'branch', defaultValue: '', description: 'Required. The release branch to create. For example: "release-0.0". This should typically be "release-MAJOR.MINOR".')
+        string(name: 'commit', defaultValue: '', description: 'Optional. Commit hash to use as the head of the branch. For example: 56b65dba917e50132b0a540ae6ff4c5bbfda2db6. If empty, the latest commit hash on the current branch will be used.')
+    }
+
+    options {
+        disableConcurrentBuilds()
+        timestamps()
+    }
+
+    environment {
+        GITHUB_UPBOUND_BOT = credentials('github-upbound-jenkins')
+    }
+
+    stages {
+
+        stage('Prepare') {
+            steps {
+                 // github credentials are not setup to push over https in jenkins. add the github token to the url
+                sh "git config remote.origin.url https://${GITHUB_UPBOUND_BOT_USR}:${GITHUB_UPBOUND_BOT_PSW}@\$(git config --get remote.origin.url | sed -e 's/https:\\/\\///')"
+                sh 'git config user.name "upbound-bot"'
+                sh 'git config user.email "info@crossplane.io"'
+                sh 'echo "machine github.com login upbound-bot password $GITHUB_UPBOUND_BOT" > ~/.netrc'
+            }
+        }
+
+        stage('Tag Release') {
+            steps {
+                sh "test -n '${params.branch}' || ( echo 'Branch is required - please enter a branch!' && exit 1 )"
+                // If the commit is not passed, it'll be empty, which means git will use the head
+                // of the current branch. Most of the time, the default behavior will be used (from master).
+                //
+                // For the push, we're assuming the remote is named "origin", but this is the convention,
+                // so it's a safe assumption for this situation.
+                sh """git branch ${params.branch} ${params.commit}
+                      git push origin ${params.branch}
+                """
+            }
+        }
+    }
+
+    post {
+        always {
+            deleteDir()
+        }
+    }
+}

--- a/Jenkinsfile.publish
+++ b/Jenkinsfile.publish
@@ -40,8 +40,6 @@ pipeline {
     post {
         always {
             script {
-                sh 'make -j\$(nproc) clean'
-                sh './bin/kubectl-crossplane-stack-build clean'
                 deleteDir()
             }
         }

--- a/Jenkinsfile.publish
+++ b/Jenkinsfile.publish
@@ -1,0 +1,49 @@
+pipeline {
+    agent { label 'upbound-gce' }
+
+    parameters {
+        string(name: 'version', defaultValue: '', description: 'The version you are publishing. For example: v0.4.0. If left unspecified, the build will generate one for you.')
+    }
+
+    options {
+        disableConcurrentBuilds()
+        timestamps()
+    }
+
+    environment {
+        DOCKER = credentials('dockerhub-upboundci')
+        CROSSPLANE_CLI_RELEASE = 'v0.2.0'
+    }
+
+    stages {
+        stage('Prepare') {
+            steps {
+                sh 'mkdir bin'
+                sh "curl -sL https://raw.githubusercontent.com/crossplaneio/crossplane-cli/${CROSSPLANE_CLI_RELEASE}/bootstrap.sh | env PREFIX=${WORKSPACE} RELEASE=${CROSSPLANE_CLI_RELEASE} bash"
+            }
+        }
+        stage('Promote Release') {
+
+            steps {
+                // The build step turns this into a "dirty" environment from the perspective of `git describe`,
+                // so we set the version once at the beginning and use it for both the build and publish steps.
+
+                sh """STACK_VERSION=${params.version}
+                      STACK_VERSION=\${STACK_VERSION:-\$( git describe --tags --dirty --always )}
+                      STACK_VERSION=\${STACK_VERSION} ./bin/kubectl-crossplane-stack-build
+                      STACK_VERSION=\${STACK_VERSION} ./bin/kubectl-crossplane-stack-publish
+                """
+            }
+        }
+    }
+
+    post {
+        always {
+            script {
+                sh 'make -j\$(nproc) clean'
+                sh './bin/kubectl-crossplane-stack-build clean'
+                deleteDir()
+            }
+        }
+    }
+}

--- a/Jenkinsfile.tag
+++ b/Jenkinsfile.tag
@@ -1,0 +1,53 @@
+pipeline {
+    agent { label 'upbound-gce' }
+
+    parameters {
+        string(name: 'version', defaultValue: '', description: 'The version you are tagging. For example: v0.4.0. If left unspecified, the build will generate one for you.')
+        string(name: 'commit', defaultValue: '', description: 'Optional commit hash to tag. For example: 56b65dba917e50132b0a540ae6ff4c5bbfda2db6. If empty, the latest commit hash will be used.')
+    }
+
+    options {
+        disableConcurrentBuilds()
+        timestamps()
+    }
+
+    environment {
+        GITHUB_UPBOUND_BOT = credentials('github-upbound-jenkins')
+    }
+
+    stages {
+
+        stage('Prepare') {
+            steps {
+                 // github credentials are not setup to push over https in jenkins. add the github token to the url
+                sh "git config remote.origin.url https://${GITHUB_UPBOUND_BOT_USR}:${GITHUB_UPBOUND_BOT_PSW}@\$(git config --get remote.origin.url | sed -e 's/https:\\/\\///')"
+                sh 'git config user.name "upbound-bot"'
+                sh 'git config user.email "info@crossplane.io"'
+                sh 'echo "machine github.com login upbound-bot password $GITHUB_UPBOUND_BOT" > ~/.netrc'
+            }
+        }
+
+        stage('Tag Release') {
+            steps {
+                // The first few lines set the version - it uses the passed version, or
+                // generates one.
+                // If the commit is not passed, it'll be empty, which means git will tag the head
+                // of the current branch. Most of the time, the default behavior will be used.
+                //
+                // For the push, we're assuming the remote is named "origin", but this is the convention,
+                // so it's a safe assumption for this situation.
+                sh """VERSION='${params.version}'
+                      VERSION=\${VERSION:-\$( git describe --tags --dirty --always )}
+                      git tag -f -m "release \${VERSION}" \${VERSION} ${params.commit}
+                      git push origin \${VERSION}
+                """
+            }
+        }
+    }
+
+    post {
+        always {
+            deleteDir()
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -1,19 +1,21 @@
 # Wordpress Sample Stack
 
 This is a Crossplane Stack that you can use to deploy Wordpress into a
-`KubernetesCluster` using a `MySQLInstance` database in the cloud. Here
-is an example CR:
+`KubernetesCluster` using a `MySQLInstance` database in the cloud.
 
 ## Installation
 
-Install with the following command after replacing `<version>` with the correct one, like `0.1.0`:
+Install with the following command after replacing `<version>` with the
+correct one, like `0.1.0`:
+
 ```bash
 kubectl crossplane stack install -n default 'crossplane/sample-stack-wordpress:<version>' wordpress
 ```
 
 ## Usage
 
-Here is an example CR that you can use to deploy Wordpress to a fresh new cluster:
+Here is an example CR that you can use to deploy Wordpress to a fresh
+new cluster:
 
 ```yaml
 apiVersion: wordpress.samples.stacks.crossplane.io/v1alpha1
@@ -37,14 +39,16 @@ Run `make`.
 
 ### Minikube
 
-Run `make` and then run the following command to copy the image into your minikube node's image registry:
+Run `make` and then run the following command to copy the image into
+your minikube node's image registry:
 
 ```bash
 # Do not forget to specify <version>
 docker save "crossplane/sample-stack-wordpress:<version>" | (eval "$(minikube docker-env --shell bash)" && docker load)
 ```
 
-After running this, you can use the [installation](#installation) command and the image loaded into minikube node will be picked up. 
+After running this, you can use the [installation](#installation)
+command and the image loaded into minikube node will be picked up. 
 
 ## Release
 

--- a/README.md
+++ b/README.md
@@ -1,0 +1,40 @@
+# Sample Stack Wordpress
+
+This is an example of a Crossplane Stack which wraps Wordpress. The
+Stack uses the Template Stacks approach, which means it does not include
+a controller of its own. Instead, it uses a Crossplane-provided
+controller; the Wordpress Stack gives the provided controller a
+configuration to define its behavior.
+
+## Developing
+
+To build:
+
+```sh
+make
+```
+
+## Releasing
+
+To create and publish a release, use the upbound Jenkins jobs. You'll
+want to have your release version handy.
+
+**A note about the multibranch pipelines we use.** We're using
+multibranch pipeline jobs in Jenkins, which means that Jenkins creates a
+new job for each branch that it detects. This means that each time a new
+branch is created, such as from the create branch job, you may need to
+trigger a new scan of the repository. It also means you may need to run
+the job once and have it fail before you can enter in parameters for the
+job.
+
+1. First, run the [job to cut a new branch](https://jenkinsci.upbound.io/job/crossplaneio/job/sample-stack-wordpress/job/branch-create/),
+   if needed. The branch should be named `release-MAJOR.MINOR`. For
+   example: `release-0.0`.
+2. If needed, edit the stack version in the release branch, so that the
+   stack version matches the version that will be released. Look for the
+   stack's metadata block.
+2. Run the [job to tag the exact release](https://jenkinsci.upbound.io/job/crossplaneio/job/sample-stack-wordpress/job/tag/)
+   we want. For example: `v0.0.1`. If you use the one on the release
+   branch we created, that's the simplest.
+4. Run the [job to publish the release](https://jenkinsci.upbound.io/job/crossplaneio/job/sample-stack-wordpress/job/publish/).
+   It's easiest if you use the branch created earlier.

--- a/stack.Makefile
+++ b/stack.Makefile
@@ -3,3 +3,7 @@ include stack.env
 build:
 	docker build . -t ${STACK_IMG}
 .PHONY: build
+
+publish:
+	docker push ${STACK_IMG}
+.PHONY: publish

--- a/stack.env
+++ b/stack.env
@@ -1,0 +1,5 @@
+# This is intended to be included from inside a Makefile
+
+# These are set if they're not already specified in environment variables.
+STACK_VERSION ?= 0.1.0
+STACK_IMG ?= crossplane/sample-stack-wordpress:$(STACK_VERSION)


### PR DESCRIPTION
Related to https://github.com/crossplane/crossplane/issues/1235

## Overview

This adds Jenkinsfiles for our publishing pipeline:

* `Jenkinsfile.tag`, for tagging commits
* `Jenkinsfile.publish`, for publishing commits to dockerhub
* `Jenkinsfile.branch`, for cutting release branches

The Jenkinsfiles are identical to the ones in #32 .

It's intended to be used in the [upbound Jenkins](https://jenkinsci.upbound.io/job/crossplaneio/job/sample-stack-wordpress), and is similar to existing publishing pipelines.

There are two types of builds:

* Continuous, from master, whenever a commit is pushed
* On-demand, from a release branch

This adds the functionality for both, but we will need additional setup to trigger the builds when a commit is pushed:

* [ ] Configure a webhook to trigger the build for the master branch

Also, out of scope are labeled channel updates (such as `alpha`).

This is similar to #32, but adds some tweaks to fit the template stacks version into the build logic.

## Testing done

I've done a bunch of testing in the [upbound Jenkins](https://jenkinsci.upbound.io/job/crossplaneio/job/sample-stack-wordpress), with a private dockerhub repository. I've done tagging and publishing and seen them succeed. I've also done some branching and see it create the branch and (intentionally) fail to push to my fork of the repository.

## After this is merged

After this is merged, we'll need to clean up the existing job and try out the process:

* [ ] Point the job back at `crossplaneio` instead of `suskin`
* [ ] Run a release of `0.1.0` using the new jobs