### PR TITLE
pipeline: add continuous build and publish

### DIFF
--- a/Jenkinsfile.continuous
+++ b/Jenkinsfile.continuous
@@ -32,7 +32,7 @@ pipeline {
                 // The build step turns this into a "dirty" environment from the perspective of `git describe`,
                 // so we set the version once at the beginning and use it for both the build and publish steps.
 
-                sh """STACK_VERSION=$( git describe --tags --dirty --always )
+                sh """STACK_VERSION=\$( git describe --tags --dirty --always )
                       STACK_VERSION=\${STACK_VERSION} ./bin/kubectl-crossplane-stack-build
                       STACK_VERSION=\${STACK_VERSION} ./bin/kubectl-crossplane-stack-publish
                 """

--- a/Jenkinsfile.continuous
+++ b/Jenkinsfile.continuous
@@ -23,7 +23,7 @@ pipeline {
         stage('Prepare') {
             steps {
                 sh 'mkdir bin'
-                sh "curl -sL https://raw.githubusercontent.com/crossplaneio/crossplane-cli/${CROSSPLANE_CLI_RELEASE}/bootstrap.sh | env PREFIX=${WORKSPACE} RELEASE=${CROSSPLANE_CLI_RELEASE} bash"
+                sh "curl -sL https://raw.githubusercontent.com/crossplane/crossplane-cli/${CROSSPLANE_CLI_RELEASE}/bootstrap.sh | env PREFIX=${WORKSPACE} RELEASE=${CROSSPLANE_CLI_RELEASE} bash"
             }
         }
         stage('Promote Release') {

--- a/Jenkinsfile.continuous
+++ b/Jenkinsfile.continuous
@@ -1,0 +1,50 @@
+// This pipeline is used to build and publish new versions of the stack when changes are merged into
+// the master branch.
+pipeline {
+    agent { label 'upbound-gce' }
+
+    options {
+        disableConcurrentBuilds()
+        timestamps()
+    }
+
+    // Checks for unprocessed changes in the repo once per day
+    // 'H' allows Jenkins to choose the time to balance the load
+    triggers {
+        pollSCM('H H * * *')
+    }
+
+    environment {
+        DOCKER = credentials('dockerhub-upboundci')
+        CROSSPLANE_CLI_RELEASE = 'v0.2.0'
+    }
+
+    stages {
+        stage('Prepare') {
+            steps {
+                sh 'mkdir bin'
+                sh "curl -sL https://raw.githubusercontent.com/crossplaneio/crossplane-cli/${CROSSPLANE_CLI_RELEASE}/bootstrap.sh | env PREFIX=${WORKSPACE} RELEASE=${CROSSPLANE_CLI_RELEASE} bash"
+            }
+        }
+        stage('Promote Release') {
+
+            steps {
+                // The build step turns this into a "dirty" environment from the perspective of `git describe`,
+                // so we set the version once at the beginning and use it for both the build and publish steps.
+
+                sh """STACK_VERSION=$( git describe --tags --dirty --always )
+                      STACK_VERSION=\${STACK_VERSION} ./bin/kubectl-crossplane-stack-build
+                      STACK_VERSION=\${STACK_VERSION} ./bin/kubectl-crossplane-stack-publish
+                """
+            }
+        }
+    }
+
+    post {
+        always {
+            script {
+                deleteDir()
+            }
+        }
+    }
+}


### PR DESCRIPTION
Related to https://github.com/crossplane/crossplane/issues/1235

## Overview

We want to publish a new version of the stack whenever a change is
merged to master. We can do this by triggering a new Jenkinsfile to run every time there is a change on the `master` branch. For other stacks, we also configure it to run every day if it hasn't run, in case a webhook call from github is dropped.

## Testing done

I haven't tested this yet, but, the commands are essentially the same as the `publish` job.