### PR TITLE
publish: remove unnecessary and broken cleans (release-0.0)

### DIFF
--- a/Jenkinsfile.publish
+++ b/Jenkinsfile.publish
@@ -40,8 +40,6 @@ pipeline {
     post {
         always {
             script {
-                sh 'make -j\$(nproc) clean'
-                sh './bin/kubectl-crossplane-stack-build clean'
                 deleteDir()
             }
         }


### PR DESCRIPTION
There are some cleans that were happening that weren't quite working,
and they aren't necessary in any case. Removing so that people aren't
confused about them in the future if they try to build using them.

## Testing done

These changes have been used in `release-0.1` to publish the `v0.1.0` image.