### PR TITLE
pipelines: use shared pipelines

### DIFF
--- a/Jenkinsfile.continuous
+++ b/Jenkinsfile.continuous
@@ -7,4 +7,4 @@ library identifier: 'crossplane-cicd@master', retriever: modernSCM(
 
 // This is the name of a file declared in vars/{{fileName}}.groovy in the library repository.
 // It configures a whole declarative pipeline for us.
-runStackBranchPipeline()
+runStackContinuousPipeline()

--- a/Jenkinsfile.publish
+++ b/Jenkinsfile.publish
@@ -1,47 +1,10 @@
-pipeline {
-    agent { label 'upbound-gce' }
+// Load a library dynamically. For more detail, see:
+// https://jenkins.io/doc/book/pipeline/shared-libraries/#defining-declarative-pipelines
+library identifier: 'crossplane-cicd@master', retriever: modernSCM(
+  [$class: 'GitSCMSource',
+   remote: 'https://github.com/crossplane/cicd',
+   credentialsId: 'github-upbound-jenkins'])
 
-    parameters {
-        string(name: 'version', defaultValue: '', description: 'The version you are publishing. For example: v0.4.0. If left unspecified, the build will generate one for you.')
-    }
-
-    options {
-        disableConcurrentBuilds()
-        timestamps()
-    }
-
-    environment {
-        DOCKER = credentials('dockerhub-upboundci')
-        CROSSPLANE_CLI_RELEASE = 'v0.2.0'
-    }
-
-    stages {
-        stage('Prepare') {
-            steps {
-                sh 'mkdir bin'
-                sh "curl -sL https://raw.githubusercontent.com/crossplaneio/crossplane-cli/${CROSSPLANE_CLI_RELEASE}/bootstrap.sh | env PREFIX=${WORKSPACE} RELEASE=${CROSSPLANE_CLI_RELEASE} bash"
-            }
-        }
-        stage('Promote Release') {
-
-            steps {
-                // The build step turns this into a "dirty" environment from the perspective of `git describe`,
-                // so we set the version once at the beginning and use it for both the build and publish steps.
-
-                sh """STACK_VERSION=${params.version}
-                      STACK_VERSION=\${STACK_VERSION:-\$( git describe --tags --dirty --always )}
-                      STACK_VERSION=\${STACK_VERSION} ./bin/kubectl-crossplane-stack-build
-                      STACK_VERSION=\${STACK_VERSION} ./bin/kubectl-crossplane-stack-publish
-                """
-            }
-        }
-    }
-
-    post {
-        always {
-            script {
-                deleteDir()
-            }
-        }
-    }
-}
+// This is the name of a file declared in vars/{{fileName}}.groovy in the library repository.
+// It configures a whole declarative pipeline for us.
+runStackPublishPipeline()

--- a/Jenkinsfile.tag
+++ b/Jenkinsfile.tag
@@ -1,53 +1,10 @@
-pipeline {
-    agent { label 'upbound-gce' }
+// Load a library dynamically. For more detail, see:
+// https://jenkins.io/doc/book/pipeline/shared-libraries/#defining-declarative-pipelines
+library identifier: 'crossplane-cicd@master', retriever: modernSCM(
+  [$class: 'GitSCMSource',
+   remote: 'https://github.com/crossplane/cicd',
+   credentialsId: 'github-upbound-jenkins'])
 
-    parameters {
-        string(name: 'version', defaultValue: '', description: 'The version you are tagging. For example: v0.4.0. If left unspecified, the build will generate one for you.')
-        string(name: 'commit', defaultValue: '', description: 'Optional commit hash to tag. For example: 56b65dba917e50132b0a540ae6ff4c5bbfda2db6. If empty, the latest commit hash will be used.')
-    }
-
-    options {
-        disableConcurrentBuilds()
-        timestamps()
-    }
-
-    environment {
-        GITHUB_UPBOUND_BOT = credentials('github-upbound-jenkins')
-    }
-
-    stages {
-
-        stage('Prepare') {
-            steps {
-                 // github credentials are not setup to push over https in jenkins. add the github token to the url
-                sh "git config remote.origin.url https://${GITHUB_UPBOUND_BOT_USR}:${GITHUB_UPBOUND_BOT_PSW}@\$(git config --get remote.origin.url | sed -e 's/https:\\/\\///')"
-                sh 'git config user.name "upbound-bot"'
-                sh 'git config user.email "info@crossplane.io"'
-                sh 'echo "machine github.com login upbound-bot password $GITHUB_UPBOUND_BOT" > ~/.netrc'
-            }
-        }
-
-        stage('Tag Release') {
-            steps {
-                // The first few lines set the version - it uses the passed version, or
-                // generates one.
-                // If the commit is not passed, it'll be empty, which means git will tag the head
-                // of the current branch. Most of the time, the default behavior will be used.
-                //
-                // For the push, we're assuming the remote is named "origin", but this is the convention,
-                // so it's a safe assumption for this situation.
-                sh """VERSION='${params.version}'
-                      VERSION=\${VERSION:-\$( git describe --tags --dirty --always )}
-                      git tag -f -m "release \${VERSION}" \${VERSION} ${params.commit}
-                      git push origin \${VERSION}
-                """
-            }
-        }
-    }
-
-    post {
-        always {
-            deleteDir()
-        }
-    }
-}
+// This is the name of a file declared in vars/{{fileName}}.groovy in the library repository.
+// It configures a whole declarative pipeline for us.
+runStackTagPipeline()


### PR DESCRIPTION
Related to crossplane/crossplane#1235

## Overview

Now that we have the pipelines moved into a repository that we can share
across Jenkins jobs, we want to use those so that we only have one copy
of the code to maintain.

## Testing

The pipelines are the same as before (plus one for continuous builds). The library loading has been tested [in this job execution](https://jenkinsci.upbound.io/job/crossplane/job/stack-minimal-gcp/job/branch-create/job/test-submodule-build/5/console).