### PR TITLE
metadata: remove app.yaml version

### DIFF
--- a/.registry/app.yaml
+++ b/.registry/app.yaml
@@ -30,11 +30,6 @@ readme: |-
 
  The stack (and Crossplane) will take care of the rest.
 
-# Version of project (optional)
-# If omitted the version will be filled with the docker tag
-# If set it must match the docker tag
-version: 0.1.0
-
 # Maintainer names and emails.
 maintainers:
 - name: Daniel Suskin


### PR DESCRIPTION
## Overview

We have observed that we appear to be treating stack version as having
two sources of truth: the app.yaml, and the docker tag. We plan to move
away from using the version in `app.yaml` as part of making it simpler
to manage the versions for our stacks.

## Testing done

I have tested this locally, and we will need https://github.com/crossplane/crossplane/issues/1307 to be done before we can merge this.