### PR TITLE
Rename to Wordpress in app.yaml

### DIFF
--- a/.registry/app.yaml
+++ b/.registry/app.yaml
@@ -1,5 +1,5 @@
 # Human readable title of application.
-title: Sample Wordpress Application
+title: Wordpress
 
 overviewShort: Cloud portable Wordpress deployments behind managed Kubernetes and SQL services are demonstrated in this Crossplane Stack.
 overview: |-


### PR DESCRIPTION
Renames from `Sample Wordpress Application` to `Wordpress`.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>