### PR TITLE
Use KubernetesApplicationResources directly

### DIFF
--- a/.registry/resources/wordpress.apps.crossplane.io_wordpressinstances.crd.yaml
+++ b/.registry/resources/wordpress.apps.crossplane.io_wordpressinstances.crd.yaml
@@ -38,16 +38,8 @@ spec:
               description: Image will be used as image of the container that Wordpress
                 runs in. If not specified, the default will be used.
               type: string
-            provisionPolicy:
-              description: ProvisionPolicy indicates whether Wordpress should be deployed
-                to an existing Kubernetes cluster or to provision a new cluster.
-              enum:
-              - ProvisionNewCluster
-              - UseExistingTarget
-              type: string
           type: object
       type: object
-  version: v1alpha1
   versions:
   - name: v1alpha1
     served: true

--- a/.registry/resources/wordpressinstance.ui-schema.yaml
+++ b/.registry/resources/wordpressinstance.ui-schema.yaml
@@ -1,16 +1,12 @@
-version: 0.1.0
+version: 0.2.0
 configSections:
-- title: Provision Details
+- title: Wordpress Settings
   items:
-  - name: provisionPolicy
-    controlType: singleSelect
-    path: .spec.provisionPolicy
-    title: Provision Policy
+  - name: image
+    controlType: singleInput
+    type: string
+    path: .spec.image
+    title: Wordpress Container Image
     default:
-    - 'ProvisionNewCluster'
-    enum:
-    - 'ProvisionNewCluster'
-    - 'UseExistingTarget'
-    validation:
-    - required: true
+    - 'wordpress:4.6.1-apache'
 initialConfig: true

--- a/README.md
+++ b/README.md
@@ -47,9 +47,6 @@ kind: WordpressInstance
 metadata:
   name: testme
 spec:
-# You can use UseExistingTarget as well to schedule to a KubernetesTarget in the
-# same namespace randomly.
-  provisionPolicy: ProvisionNewCluster
 
 #  This is the default value.
 # image: wordpress:4.6.1-apache

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -439,8 +439,6 @@ kind: WordpressInstance
 metadata:
   namespace: workspace1
   name: my-cool-app
-spec:
-  provisionPolicy: ProvisionNewCluster
 ```
 
 Then apply it:

--- a/example.yaml
+++ b/example.yaml
@@ -3,9 +3,5 @@ kind: WordpressInstance
 metadata:
   name: testme
 spec:
-# You can use UseExistingTarget as well to schedule to a KubernetesTarget in the
-# same namespace randomly.
-  provisionPolicy: ProvisionNewCluster
-
 #  This is the default value in templates folder.
 # image: wordpress:4.6.1-apache

--- a/helm-chart/templates/app.yaml
+++ b/helm-chart/templates/app.yaml
@@ -1,107 +1,107 @@
 ---
 apiVersion: workload.crossplane.io/v1alpha1
-kind: KubernetesApplication
+kind: KubernetesApplicationResource
 metadata:
-  name: {{ .Release.Name }}-app
+  name: {{ .Release.Name }}-namespace
   labels:
     app: {{ .Release.Name }}
   annotations:
     templatestacks.crossplane.io/deletion-priority: "1"
 spec:
-  resourceSelector:
-    matchLabels:
-      app: {{ .Release.Name }}
-  targetSelector:
-  {{ if ne (.Values.provisionPolicy | default "ProvisionNewCluster") "UseExistingTarget" }}
-    matchLabels:
-      app: {{ .Release.Name }}
-  {{ else }}
-    matchLabels: {}
-  {{ end }}
-  resourceTemplates:
-    - metadata:
-        name: {{ .Release.Name }}-namespace
-        labels:
-          app: {{ .Release.Name }}
-      spec:
-        template:
-          apiVersion: v1
-          kind: Namespace
-          metadata:
-            name: {{ .Release.Name }}
-            labels:
-              app: wordpress
-    - metadata:
-        name: {{ .Release.Name }}-deployment
-        labels:
-          app: {{ .Release.Name }}
-      spec:
-        secrets:
-          # This must match the writeConnectionSecretToRef field
-          # on the database claim; it is the name of the secret to
-          # pull from the crossplane cluster, from this Application's namespace.
-          - name: sql
-        template:
-          apiVersion: apps/v1
-          kind: Deployment
-          metadata:
-            namespace: {{ .Release.Name }}
-            name: wordpress
-            labels:
-              app: wordpress
-          spec:
-            selector:
-              matchLabels:
-                app: wordpress
-            template:
-              metadata:
-                labels:
-                  app: wordpress
-              spec:
-                containers:
-                  - name: wordpress
-                    image: {{ .Values.image | default "wordpress:4.6.1-apache" | quote }}
-                    env:
-                      - name: WORDPRESS_DB_HOST
-                        valueFrom:
-                          secretKeyRef:
-                            # This is the name of the secret to use to consume the secret
-                            # within the managed cluster. The reason it's different from the
-                            # name of the secret above is because within the managed cluster,
-                            # a crossplane-managed secret is written as '{metadata.name}-{secretname}'.
-                            # The metadata name is specified above for this resource, and so is
-                            # the secret name.
-                            name: {{ .Release.Name }}-deployment-sql
-                            key: endpoint
-                      - name: WORDPRESS_DB_USER
-                        valueFrom:
-                          secretKeyRef:
-                            name: {{ .Release.Name }}-deployment-sql
-                            key: username
-                      - name: WORDPRESS_DB_PASSWORD
-                        valueFrom:
-                          secretKeyRef:
-                            name: {{ .Release.Name }}-deployment-sql
-                            key: password
-                    ports:
-                      - containerPort: 80
-                        name: wordpress
-    - metadata:
-        name: {{ .Release.Name }}-service
-        labels:
-          app: {{ .Release.Name }}
-      spec:
-        template:
-          apiVersion: v1
-          kind: Service
-          metadata:
-            namespace: {{ .Release.Name }}
-            name: wordpress
-            labels:
-              app: wordpress
-          spec:
-            ports:
-              - port: 80
-            selector:
-              app: wordpress
-            type: LoadBalancer
+  credentialsRef:
+    name: {{ .Release.Name }}-cluster
+    key: kubeconfig
+  template:
+    apiVersion: v1
+    kind: Namespace
+    metadata:
+      name: {{ .Release.Name }}
+      labels:
+        app: wordpress
+---
+apiVersion: workload.crossplane.io/v1alpha1
+kind: KubernetesApplicationResource
+metadata:
+  name: {{ .Release.Name }}-deployment
+  labels:
+    app: {{ .Release.Name }}
+  annotations:
+    templatestacks.crossplane.io/deletion-priority: "1"
+spec:
+  credentialsRef:
+    name: {{ .Release.Name }}-cluster
+    key: kubeconfig
+  secrets:
+    - name: {{ .Release.Name }}-sql
+  template:
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      namespace: {{ .Release.Name }}
+      name: wordpress
+      labels:
+        app: wordpress
+    spec:
+      selector:
+        matchLabels:
+          app: wordpress
+      template:
+        metadata:
+          labels:
+            app: wordpress
+        spec:
+          containers:
+            - name: wordpress
+              image: {{ .Values.image | default "wordpress:4.6.1-apache" | quote }}
+              env:
+                - name: WORDPRESS_DB_HOST
+                  valueFrom:
+                    secretKeyRef:
+                      # This is the name of the secret to use to consume the secret
+                      # within the managed cluster. The reason it's different from the
+                      # name of the secret above is because within the managed cluster,
+                      # a crossplane-managed secret is written as '{metadata.name}-{secretname}'.
+                      # The metadata name is specified above for this resource, and so is
+                      # the secret name.
+                      name: {{ .Release.Name }}-deployment-{{ .Release.Name }}-sql
+                      key: endpoint
+                - name: WORDPRESS_DB_USER
+                  valueFrom:
+                    secretKeyRef:
+                      name: {{ .Release.Name }}-deployment-{{ .Release.Name }}-sql
+                      key: username
+                - name: WORDPRESS_DB_PASSWORD
+                  valueFrom:
+                    secretKeyRef:
+                      name: {{ .Release.Name }}-deployment-{{ .Release.Name }}-sql
+                      key: password
+              ports:
+                - containerPort: 80
+                  name: wordpress
+---
+apiVersion: workload.crossplane.io/v1alpha1
+kind: KubernetesApplicationResource
+metadata:
+  name: {{ .Release.Name }}-service
+  labels:
+    app: {{ .Release.Name }}
+  annotations:
+    templatestacks.crossplane.io/deletion-priority: "1"
+spec:
+  credentialsRef:
+    name: {{ .Release.Name }}-cluster
+    key: kubeconfig
+  template:
+    apiVersion: v1
+    kind: Service
+    metadata:
+      namespace: {{ .Release.Name }}
+      name: wordpress
+      labels:
+        app: wordpress
+    spec:
+      ports:
+        - port: 80
+      selector:
+        app: wordpress
+      type: LoadBalancer

--- a/helm-chart/templates/cluster.yaml
+++ b/helm-chart/templates/cluster.yaml
@@ -1,4 +1,3 @@
-{{ if ne (.Values.provisionPolicy | default "ProvisionNewCluster") "UseExistingTarget" }}
 apiVersion: compute.crossplane.io/v1alpha1
 kind: KubernetesCluster
 metadata:
@@ -16,5 +15,4 @@ metadata:
 spec:
   writeConnectionSecretToRef:
     name: {{ .Release.Name }}-cluster
-{{ end }}
 

--- a/helm-chart/templates/database.yaml
+++ b/helm-chart/templates/database.yaml
@@ -9,4 +9,4 @@ spec:
   # to export it under. This is the name of the secret
   # in the crossplane cluster, and it's scoped to this claim's namespace.
   writeConnectionSecretToRef:
-    name: sql
+    name: {{ .Release.Name }}-sql

--- a/helm-chart/values.yaml
+++ b/helm-chart/values.yaml
@@ -1,2 +1,1 @@
 image: wordpress:4.6.1-apache
-provisionPolicy: ProvisionNewCluster


### PR DESCRIPTION
New `KubernetesApplicationResource` has a field to supply the connection secret of Kubernetes cluster directly. We need to use it as claims are depracated and Wordpress app will use a Kubernetes cluster type defined via an `InfrastructureDefinition`.

Depends on https://github.com/crossplane/crossplane/pull/1604